### PR TITLE
removed --reload as it taking up extra cpu and is of no use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: ./server/Dockerfile
-    command: uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 3000
+    command: uvicorn app.main:app --workers 1 --host 0.0.0.0 --port 3000
     restart: unless-stopped    
     ports:
       - "3000:3000"


### PR DESCRIPTION
docker image is read only, therefore uvicorn app.main:app `--reload` is not required