### PR TITLE
feat: Filter out 'thought' messages in DevBot component

### DIFF
--- a/studio/src/components/Chat/DevBot.tsx
+++ b/studio/src/components/Chat/DevBot.tsx
@@ -82,7 +82,15 @@ export const devBot = (props:props) => {
                     console.log(error);
                 }
             }
-            addMessages((messages: any) => [lastJsonMessage, ...messages])
+            if (lastJsonMessage.type === 'thought') {
+                addMessages((messages: any) => {
+                    const filteredMessages = messages.filter((msg: any) => msg.type !== 'thought');
+                    return [lastJsonMessage, ...filteredMessages];
+                });
+            }
+            else{
+                addMessages((messages: any) => [lastJsonMessage, ...messages])
+            }
             scrollChatToBottom();
         }
     }, [lastJsonMessage, addMessages]);


### PR DESCRIPTION
The code changes in `DevBot.tsx` add a conditional check to filter out messages of type 'thought' before adding them to the list of messages. This ensures there is only one thought message.

This makes sure that there are not bombing of "thought" messages. 